### PR TITLE
Dualboot Win10 21H1 ISO uefi/bios

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-slate


### PR DESCRIPTION
UEFI/BIOS Dualboot support Windows OS 21H1 with all in one in DLA Microsoft Store commercial version and the already paid OEM stall version for all as Tablets and Personal Computers without need of SSD or HDD conversion to MBR or GPT as it is able to boot both sides of internal chip if it has been manufacturely set for either one as efi only made table compute the safety has been made valuable and you can download this measure using Power ISO to Flash drive or burn to DVD CD ROM
![GitHub REPO](https://user-images.githubusercontent.com/91020186/136625057-b7d27bc0-a3f8-4c5a-a131-29efc8951262.png)
